### PR TITLE
`BigQuery.await` throw JobTimeoutException at high frequency.

### DIFF
--- a/src/main/scala/bigquery4s/BigQuery.scala
+++ b/src/main/scala/bigquery4s/BigQuery.scala
@@ -82,10 +82,11 @@ case class BigQuery(
   }
 
   def await(jobId: JobId, timeoutSeconds: Int = 300): WrappedCompletedJob = {
-    val job = underlying.jobs.get(jobId.projectId.value, jobId.value).execute()
+    var job = underlying.jobs.get(jobId.projectId.value, jobId.value).execute()
     (1 to timeoutSeconds).foreach { i =>
       if (job.getStatus.getState != "DONE") {
         Thread.sleep(1000)
+        job = underlying.jobs.get(jobId.projectId.value, jobId.value).execute()
       }
     }
     if (job.getStatus.getState != "DONE") {


### PR DESCRIPTION
`job.getStatus.getState` was allways return to "RUNNING".

should update of `job` parameter?
