### PR TITLE
Fix NullPointer Exception on empty query result.

### DIFF
--- a/src/main/scala/bigquery4s/BigQuery.scala
+++ b/src/main/scala/bigquery4s/BigQuery.scala
@@ -83,7 +83,7 @@ case class BigQuery(
     val response: GetQueryResultsResponse = underlying.jobs
       .getQueryResults(job.getJobReference.getProjectId, job.getJobReference.getJobId)
       .execute()
-    response.getRows.asScala.toSeq.map(WrappedTableRow)
+    Option(response.getRows).map(_.asScala.toSeq.map(WrappedTableRow)).getOrElse(Nil)
   }
 
 }


### PR DESCRIPTION
When BigQuery returns zero record for a query, `response.getRows` returns `null`.
