### PR TITLE
add BigQuery.fromServiceAccountJson

### DIFF
--- a/src/main/scala/bigquery4s/BigQuery.scala
+++ b/src/main/scala/bigquery4s/BigQuery.scala
@@ -148,4 +148,18 @@ object BigQuery {
     BigQuery(transport, jsonFactory, credential)
   }
 
+  def fromServiceAccountJson(
+    serviceAccountJsonFilePath: String = homeDir + "/.bigquery/service_account.json",
+    transport: HttpTransport = new NetHttpTransport,
+    jsonFactory: JsonFactory = new JacksonFactory,
+    scopes: Seq[String] = Seq(BigqueryScopes.BIGQUERY)
+  ): BigQuery = {
+
+    val credential = using(new FileInputStream(serviceAccountJsonFilePath)) { in =>
+      GoogleCredential.fromStream(in).createScoped(scopes.asJava)
+    }
+
+    BigQuery(transport, jsonFactory, credential)
+  }
+
 }


### PR DESCRIPTION
This fixes some of the issues in https://github.com/seratch/bigquery4s/issues/5 - namely, making it possible to connect with a service account json credentials file. 

I tested it locally by building the jar and including it in my project. Then this works:

```scala
val bq = BigQuery.fromServiceAccountJson("/tmp/service_account.json")
val jobId = bq.startQuery("some-project", "SELECT * FROM some_table")
val job = bq.await(jobId)
val rows = bq.getRows(job)
val output = rows.map(_.cells.map(_.value.orNull).mkString(",")).mkString("\n")
```