### PR TITLE
add fromServiceAccountJsonInputStream

### DIFF
--- a/src/main/scala/bigquery4s/BigQuery.scala
+++ b/src/main/scala/bigquery4s/BigQuery.scala
@@ -155,7 +155,11 @@ object BigQuery {
     scopes: Seq[String] = Seq(BigqueryScopes.BIGQUERY)
   ): BigQuery = {
 
-    BigQuery.fromServiceAccountJsonInputStream(new FileInputStream(serviceAccountJsonFilePath), transport, jsonFactory, scopes)
+    val credential = using(new FileInputStream(serviceAccountJsonFilePath)) { in =>
+      GoogleCredential.fromStream(in).createScoped(scopes.asJava)
+    }
+
+    BigQuery(transport, jsonFactory, credential)
   }
 
   def fromServiceAccountJsonInputStream(

--- a/src/main/scala/bigquery4s/BigQuery.scala
+++ b/src/main/scala/bigquery4s/BigQuery.scala
@@ -1,6 +1,6 @@
 package bigquery4s
 
-import java.io.{ File, InputStreamReader, FileInputStream }
+import java.io.{ File, InputStream, InputStreamReader, FileInputStream }
 
 import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp
@@ -155,7 +155,17 @@ object BigQuery {
     scopes: Seq[String] = Seq(BigqueryScopes.BIGQUERY)
   ): BigQuery = {
 
-    val credential = using(new FileInputStream(serviceAccountJsonFilePath)) { in =>
+    BigQuery.fromServiceAccountJsonInputStream(new FileInputStream(serviceAccountJsonFilePath), transport, jsonFactory, scopes)
+  }
+
+  def fromServiceAccountJsonInputStream(
+    serviceAccountJsonInputStream: InputStream,
+    transport: HttpTransport = new NetHttpTransport,
+    jsonFactory: JsonFactory = new JacksonFactory,
+    scopes: Seq[String] = Seq(BigqueryScopes.BIGQUERY)
+  ): BigQuery = {
+
+    val credential = using(serviceAccountJsonInputStream) { in =>
       GoogleCredential.fromStream(in).createScoped(scopes.asJava)
     }
 

--- a/src/test/scala/bigquery4s/ServiceAccountUsageExamplesSpec.scala
+++ b/src/test/scala/bigquery4s/ServiceAccountUsageExamplesSpec.scala
@@ -1,0 +1,77 @@
+package bigquery4s
+
+import java.io.FileInputStream
+
+import org.scalatest._
+import org.slf4j.LoggerFactory
+
+/**
+ * requirement: $HOME/.bigquery/service_account.json
+ */
+class ServiceAccountUsageExamplesSpec extends FunSpec with Matchers {
+
+  lazy val logger = LoggerFactory.getLogger(classOf[UsageExamplesSpec])
+  val yourOwnProjectId = "thinking-digit-98014"
+
+  describe("Simple query example with publicdata using service account json file") {
+    it("runs") {
+      val bq = BigQuery.fromServiceAccountJson()
+
+      val datasets: Seq[WrappedDatasets] = bq.listDatasets("publicdata")
+      logger.info(datasets.mkString("\n"))
+
+      val query = """
+        SELECT weight_pounds,state,year,gestation_weeks FROM publicdata:samples.natality
+        ORDER BY weight_pounds DESC LIMIT 100;
+      """
+      val jobId: JobId = bq.startQuery(yourOwnProjectId, query)
+      logger.info(s"JobId: $jobId")
+
+      val job: WrappedCompletedJob = bq.await(jobId)
+      logger.info(s"Job: $job")
+
+      val rows: Seq[WrappedTableRow] = bq.getRows(job)
+      val sampleCsv = rows.take(20).map(_.cells.map(_.value.orNull).mkString(","))
+      logger.info(s"""
+                     |*** QueryResult ***
+                     |
+       |weight_pounds,state,year,gestation_weeks
+                     |${sampleCsv.mkString("\n")}
+                     |""".stripMargin)
+    }
+  }
+
+  describe("Simple query example with publicdata using service account json string") {
+    it("runs") {
+      using(new FileInputStream(homeDir + "/.bigquery/service_account.json")) { in =>
+        val bq = BigQuery.fromServiceAccountJsonInputStream(in)
+
+        val datasets: Seq[WrappedDatasets] = bq.listDatasets("publicdata")
+        logger.info(datasets.mkString("\n"))
+
+        val query =
+          """
+          SELECT weight_pounds,state,year,gestation_weeks FROM publicdata:samples.natality
+          ORDER BY weight_pounds DESC LIMIT 100;
+        """
+        val jobId: JobId = bq.startQuery(yourOwnProjectId, query)
+        logger.info(s"JobId: $jobId")
+
+        val job: WrappedCompletedJob = bq.await(jobId)
+        logger.info(s"Job: $job")
+
+        val rows: Seq[WrappedTableRow] = bq.getRows(job)
+        val sampleCsv = rows.take(20).map(_.cells.map(_.value.orNull).mkString(","))
+        logger.info(s"""
+                       |*** QueryResult ***
+                       |
+         |weight_pounds,state,year,gestation_weeks
+                       |${
+          sampleCsv.
+            mkString("\n")
+        }
+                       |""".stripMargin)
+      }
+    }
+  }
+}


### PR DESCRIPTION
similar to the `BigQuery.fromServiceAccountJson` (that expects a file path), this new method allows you to pass in an `InputStream`.  We have a use-case where all configuration is happening via ENV vars, and I'd prefer to not have to write the config to the local (container) filesystem.

I also added a test for both of the service account json methods I have added.  Same as the existing test, it requires you change `yourOwnProjectId` and to have a file existing at `$HOME/.bigquery/service_account.json`:

```scala
> testOnly *ServiceAccountUsageExamplesSpec
[info] Formatting 1 Scala source {file:/Users/vramesh/oss/bigquery4s/}root(test) ...
[info] Formatting 1 Scala source {file:/Users/vramesh/oss/bigquery4s/}root(compile) ...
[info] Compiling 1 Scala source to /Users/vramesh/oss/bigquery4s/target/scala-2.12/classes...
[info] Compiling 1 Scala source to /Users/vramesh/oss/bigquery4s/target/scala-2.12/test-classes...
[info] ServiceAccountUsageExamplesSpec:
[info] Simple query example with publicdata using service account json file
Oct 23, 2017 10:48:10 AM com.google.api.client.googleapis.services.AbstractGoogleClient <init>
WARNING: Application name is not set. Call Builder#setApplicationName.
2017-10-23 10:48:11,608 INFO bigquery4s.UsageExamplesSpec WrappedDatasets({"datasetReference":{"datasetId":"samples","projectId":"publicdata"},"id":"publicdata:samples","kind":"bigquery#dataset"})
2017-10-23 10:48:12,719 INFO bigquery4s.UsageExamplesSpec JobId: JobId(ProjectId(REDACTED),job_-s7T-GAUeKvcYxyH9tHNAxp24KWf)
2017-10-23 10:48:12,991 INFO bigquery4s.UsageExamplesSpec Job: WrappedCompletedJob({"configuration":{"query":{"createDisposition":"CREATE_IF_NEEDED","destinationTable":{"datasetId":"_05fb90c360272d1beef3822267407d6db9668147","projectId":"REDACTED","tableId":"anon3fc6a91182188a91987aa4f1347569a2e9c8631b"},"query":"\n        SELECT weight_pounds,state,year,gestation_weeks FROM publicdata:samples.natality\n        ORDER BY weight_pounds DESC LIMIT 100;\n      ","writeDisposition":"WRITE_TRUNCATE"}},"etag":"\"SdUekaVqp4U9n5pPfq5AV4uIdyk/YuWvQ10O8vfZNFDTfivjFFZsmco\"","id":"REDACTED:job_-s7T-GAUeKvcYxyH9tHNAxp24KWf","jobReference":{"jobId":"job_-s7T-GAUeKvcYxyH9tHNAxp24KWf","projectId":"REDACTED"},"kind":"bigquery#job","selfLink":"https://www.googleapis.com/bigquery/v2/projects/REDACTED/jobs/job_-s7T-GAUeKvcYxyH9tHNAxp24KWf","statistics":{"creationTime":"1508780891716","endTime":"1508780892405","query":{"cacheHit":true,"totalBytesBilled":"0","totalBytesProcessed":"0"},"startTime":"1508780892210","totalBytesProcessed":"0"},"status":{"state":"DONE"},"user_email":"REDACTED@REDACTED.iam.gserviceaccount.com"})
2017-10-23 10:48:13,279 INFO bigquery4s.UsageExamplesSpec
*** QueryResult ***

weight_pounds,state,year,gestation_weeks
18.0007436923,null,2008,null
18.0007436923,null,2008,32
18.0007436923,null,2007,38
18.0007436923,null,2006,null
18.0007436923,KY,2004,38
18.0007436923,null,2005,null
18.0007436923,null,2007,null
18.0007436923,null,2005,40
18.0007436923,null,2006,37
18.0007436923,null,2005,42
18.0007436923,KY,2004,47
18.0007436923,KY,2004,41
18.0007436923,TX,1969,null
18.0007436923,KY,2004,39
18.0007436923,KY,2004,47
18.0007436923,null,2006,39
18.0007436923,null,2005,42
18.0007436923,KY,2004,47
18.0007436923,null,2005,35
18.0007436923,KY,2004,47

[info] - runs
[info] Simple query example with publicdata using service account json string
Oct 23, 2017 10:48:13 AM com.google.api.client.googleapis.services.AbstractGoogleClient <init>
WARNING: Application name is not set. Call Builder#setApplicationName.
2017-10-23 10:48:13,582 INFO bigquery4s.UsageExamplesSpec WrappedDatasets({"datasetReference":{"datasetId":"samples","projectId":"publicdata"},"id":"publicdata:samples","kind":"bigquery#dataset"})
2017-10-23 10:48:13,939 INFO bigquery4s.UsageExamplesSpec JobId: JobId(ProjectId(REDACTED),job_eELt2uPdtORwxOIBApXFsa7mVyEn)
2017-10-23 10:48:14,123 INFO bigquery4s.UsageExamplesSpec Job: WrappedCompletedJob({"configuration":{"query":{"createDisposition":"CREATE_IF_NEEDED","destinationTable":{"datasetId":"_05fb90c360272d1beef3822267407d6db9668147","projectId":"REDACTED","tableId":"anon3fc6a91182188a91987aa4f1347569a2e9c8631b"},"query":"\n          SELECT weight_pounds,state,year,gestation_weeks FROM publicdata:samples.natality\n          ORDER BY weight_pounds DESC LIMIT 100;\n        ","writeDisposition":"WRITE_TRUNCATE"}},"etag":"\"SdUekaVqp4U9n5pPfq5AV4uIdyk/ePu_0fQijyMGuQmEJ3dUSmRHgao\"","id":"REDACTED:job_eELt2uPdtORwxOIBApXFsa7mVyEn","jobReference":{"jobId":"job_eELt2uPdtORwxOIBApXFsa7mVyEn","projectId":"REDACTED"},"kind":"bigquery#job","selfLink":"https://www.googleapis.com/bigquery/v2/projects/REDACTED/jobs/job_eELt2uPdtORwxOIBApXFsa7mVyEn","statistics":{"creationTime":"1508780893661","endTime":"1508780893800","query":{"cacheHit":true,"totalBytesBilled":"0","totalBytesProcessed":"0"},"startTime":"1508780893772","totalBytesProcessed":"0"},"status":{"state":"DONE"},"user_email":"REDACTED@REDACTED.iam.gserviceaccount.com"})
2017-10-23 10:48:14,397 INFO bigquery4s.UsageExamplesSpec
*** QueryResult ***

weight_pounds,state,year,gestation_weeks
18.0007436923,null,2008,null
18.0007436923,null,2008,32
18.0007436923,null,2007,38
18.0007436923,null,2006,null
18.0007436923,KY,2004,38
18.0007436923,null,2005,null
18.0007436923,null,2007,null
18.0007436923,null,2005,40
18.0007436923,null,2006,37
18.0007436923,null,2005,42
18.0007436923,KY,2004,47
18.0007436923,KY,2004,41
18.0007436923,TX,1969,null
18.0007436923,KY,2004,39
18.0007436923,KY,2004,47
18.0007436923,null,2006,39
18.0007436923,null,2005,42
18.0007436923,KY,2004,47
18.0007436923,null,2005,35
18.0007436923,KY,2004,47

[info] - runs
[info] Run completed in 4 seconds, 148 milliseconds.
[info] Total number of tests run: 2
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 2, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```