### PR TITLE
Added implicit StringContexts for standard and legacy SQL

### DIFF
--- a/src/main/scala/bigquery4s/interpolation/BQInterpolationString.scala
+++ b/src/main/scala/bigquery4s/interpolation/BQInterpolationString.scala
@@ -1,0 +1,37 @@
+package bigquery4s.interpolation
+
+import bigquery4s.{BigQuery, ProjectId, WrappedTableRow}
+
+class BQInterpolationString(private val s: StringContext) extends AnyVal {
+
+  /**
+    * StringContext for the standard SQL
+    *
+    * @param args he arguments to be inserted into the resulting query.
+    * @param bq implicit BigQuery configuration
+    * @param projectId implicit declaration of ProjectId
+    * @return
+    */
+  def bqs(args: Any*)(bq: BigQuery, projectId: ProjectId): Seq[WrappedTableRow] =
+    bq.getRows(
+      bq.await(
+        bq.startStandardQuery(
+          projectId,
+          s.standardInterpolator(StringContext.treatEscapes, args))))
+
+  /**
+    * StringContext for the legacy SQL
+    *
+    * @param args he arguments to be inserted into the resulting query.
+    * @param bq implicit BigQuery configuration
+    * @param projectId implicit declaration of ProjectId
+    * @return
+    */
+  def bql(args: Any*)(bq: BigQuery, projectId: ProjectId): Seq[WrappedTableRow] =
+    bq.getRows(
+      bq.await(
+        bq.startQuery(
+          projectId,
+          s.standardInterpolator(StringContext.treatEscapes, args))))
+
+}

--- a/src/main/scala/bigquery4s/interpolation/BQInterpolationString.scala
+++ b/src/main/scala/bigquery4s/interpolation/BQInterpolationString.scala
@@ -12,7 +12,7 @@ class BQInterpolationString(private val s: StringContext) extends AnyVal {
     * @param projectId implicit declaration of ProjectId
     * @return
     */
-  def bqs(args: Any*)(bq: BigQuery, projectId: ProjectId): Seq[WrappedTableRow] =
+  def bqs(args: Any*)(implicit bq: BigQuery, projectId: ProjectId): Seq[WrappedTableRow] =
     bq.getRows(
       bq.await(
         bq.startStandardQuery(
@@ -27,7 +27,7 @@ class BQInterpolationString(private val s: StringContext) extends AnyVal {
     * @param projectId implicit declaration of ProjectId
     * @return
     */
-  def bql(args: Any*)(bq: BigQuery, projectId: ProjectId): Seq[WrappedTableRow] =
+  def bql(args: Any*)(implicit bq: BigQuery, projectId: ProjectId): Seq[WrappedTableRow] =
     bq.getRows(
       bq.await(
         bq.startQuery(

--- a/src/main/scala/bigquery4s/interpolation/BQSyntax.scala
+++ b/src/main/scala/bigquery4s/interpolation/BQSyntax.scala
@@ -1,0 +1,10 @@
+package bigquery4s.interpolation
+
+import bigquery4s.{BigQuery, ProjectId}
+
+trait BQSyntax extends Implicits {
+
+  implicit val bq: BigQuery
+  implicit val projectId: ProjectId
+
+}

--- a/src/main/scala/bigquery4s/interpolation/Implicits.scala
+++ b/src/main/scala/bigquery4s/interpolation/Implicits.scala
@@ -1,0 +1,25 @@
+package bigquery4s.interpolation
+
+import scala.language.implicitConversions
+
+/**
+  * object to import.
+  */
+object Implicits extends Implicits
+
+/**
+  * Implicit conversion imports.
+  */
+trait Implicits {
+
+  /**
+    * Enables bqs"", bql"" interpolation.
+    *
+    * {{{
+    *   bqs"select * from ds,members"
+    *   bql"select * from ds.members"
+    * }}}
+    */
+  @inline implicit def bigquery4sSQLInterpolationImplicitDef(s: StringContext): BQInterpolationString = new BQInterpolationString(s)
+}
+

--- a/src/test/scala/bigquery4s/UsageExamplesSpec.scala
+++ b/src/test/scala/bigquery4s/UsageExamplesSpec.scala
@@ -10,14 +10,16 @@ class UsageExamplesSpec extends FunSpec with Matchers {
 
   lazy val logger = LoggerFactory.getLogger(classOf[UsageExamplesSpec])
 
+  val yourOwnProjectId: String = "thinking-digit-98014"
+  implicit val bq: BigQuery = BigQuery()
+  implicit val projectId: ProjectId = ProjectId(yourOwnProjectId)
+
   describe("Simple query example with publicdata") {
     it("runs") {
-      val bq = BigQuery()
 
       val datasets: Seq[WrappedDatasets] = bq.listDatasets("publicdata")
       logger.info(datasets.mkString("\n"))
 
-      val yourOwnProjectId = "thinking-digit-98014"
       val query = """
         SELECT weight_pounds,state,year,gestation_weeks FROM publicdata:samples.natality
         ORDER BY weight_pounds DESC LIMIT 100;
@@ -36,6 +38,40 @@ class UsageExamplesSpec extends FunSpec with Matchers {
        |weight_pounds,state,year,gestation_weeks
        |${sampleCsv.mkString("\n")}
        |""".stripMargin)
+    }
+  }
+
+  describe("Simple legacy sql query example with publicdata") {
+    it("runs") {
+      import bigquery4s.interpolation.Implicits._
+
+      val rows: Seq[WrappedTableRow] =
+        bql"SELECT weight_pounds,state,year,gestation_weeks FROM publicdata:samples.natality ORDER BY weight_pounds DESC LIMIT 100;"
+      val sampleCsv = rows.take(20).map(_.cells.map(_.value.orNull).mkString(","))
+
+      logger.info(s"""
+        |*** QueryResult ***
+        |
+        |weight_pounds,state,year,gestation_weeks
+        |${sampleCsv.mkString("\n")}
+        |""".stripMargin)
+    }
+  }
+
+  describe("Simple standard sql query example with publicdata") {
+    it("runs") {
+      import bigquery4s.interpolation.Implicits._
+
+      val rows: Seq[WrappedTableRow] =
+        bql"SELECT weight_pounds,state,year,gestation_weeks FROM publicdata.samples.natality ORDER BY weight_pounds DESC LIMIT 100;"
+      val sampleCsv = rows.take(20).map(_.cells.map(_.value.orNull).mkString(","))
+
+      logger.info(s"""
+        |*** QueryResult ***
+        |
+        |weight_pounds,state,year,gestation_weeks
+        |${sampleCsv.mkString("\n")}
+        |""".stripMargin)
     }
   }
 }


### PR DESCRIPTION
Added implicit StringContexts for standard and legacy SQL

bqs for standard and bql for legacy, these will run the queries and will get the rows as a `Seq[WrappedTableRow]`.
e.g:
```scala
bqs"select * from ds.member"
bql"select * from ds.member"
```
The implicits are created in "Implicits" and are extended by BQSyntax. to be able to use these you need to extend your model with it and create an implicit projectId and an implicit bigquery4s.BigQuery.

It will anyway force you to create a projectId and a bigquery4s.BigQuery at the Member level. Something like this:

```scala
object Member(id: Option[String], name: String)
class Member extends BQSyntax {
  override val bq: BigQuery = BigQuery()
  override val projectId: ProjectId = ProjectId("some_project")

  def apply()(wr: WrappedTableRow): Member = new Member(wr.stringOpt("id"), wr.string("name"))

  //The mapping to the Member object will come in a future PR
  bqs"select * from ds.member".map(Member(_))
}
```

Do you think this is a good way to set bq and projectId? @seratch 